### PR TITLE
docs: fix reviewer preference typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ LatteReview is a powerful Python package designed to automate academic literatur
 - Multi-agent review system with customizable roles and expertise levels for each reviewer
 - Support for multiple review rounds with hierarchical decision-making workflows
 - Review diverse content types including article titles, abstracts, custom texts, and even **images** using LLM-powered reviewer agents
-- Define reviewer agents with specialized backgrounds and distinct evaluation capabilities (e.g., scoring or concept abstraction or custom reviewers of your own preferance)
+- Define reviewer agents with specialized backgrounds and distinct evaluation capabilities (e.g., scoring or concept abstraction or custom reviewers of your own preference)
 - Create flexible review workflows where multiple agents operate in parallel or sequential arrangements
 - Enable reviewer agents to analyze peer feedback, cast votes, and propose corrections to other reviewers' assessments
 - Enhance reviews with item-specific context integration, supporting use cases like **Retrieval Augmented Generation (RAG)**


### PR DESCRIPTION
## Summary
- fix a visible `preferance` typo in the documentation overview

## Validation
- `git diff --check`
- `git grep -n preferance -- docs/index.md` returns no matches

## Confidence
Score: 85/100 (docs/typo). The change is a single spelling fix in user-facing documentation.